### PR TITLE
Fix InternalError in StaticPlanBlockMemory when visiting DataflowBlockNode

### DIFF
--- a/src/relax/transform/static_plan_block_memory.cc
+++ b/src/relax/transform/static_plan_block_memory.cc
@@ -730,6 +730,15 @@ class StorageAllocator : public StorageAllocatorBaseVisitor {
     }
   }
 
+  void VisitBindingBlock_(const DataflowBlockNode* block) override {
+    // We maintain a block stack for token allocation-site and use-site check.
+    block_stack_.push_back(block);
+    ExprVisitor::VisitBindingBlock_(block);
+    ICHECK(!block_stack_.empty());
+    ICHECK(block_stack_.back() == block);
+    block_stack_.pop_back();
+  }
+
   void VisitBinding_(const VarBindingNode* binding, const CallNode* call) final {
     static const Op& alloc_tensor_op = Op::Get("relax.builtin.alloc_tensor");
     if (call->op == alloc_tensor_op) {


### PR DESCRIPTION
This error happens because the visitor class StorageAllocatorBaseVisitor does not correctly handle DataflowBlockNode instances. Specifically, the VisitBindingBlock_ method is not overridden for DataflowBlockNode, leading to an empty block_stack_ when it is expected to contain the current block.

To fix this issue, we need to override the VisitBindingBlock_ method for const DataflowBlockNode* in the StorageAllocatorBaseVisitor class. By doing so, we ensure that the block_stack_ is correctly managed when visiting dataflow blocks, similar to how it is managed for regular binding blocks.